### PR TITLE
Use 'uname -m' to detect system architecture and install correct binaries for host systems

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -3,7 +3,14 @@
 set -euo pipefail
 
 get_platform() {
-  echo "$(uname | tr '[:upper:]' '[:lower:]')_amd64"
+  arch=$(uname -m)
+  case $arch in
+    armv*) arch="arm";;
+    arm64) arch="arm64";; # m1 macs
+    aarch64) arch="arm64";;
+    *) arch="amd64";;
+  esac
+  echo "$(uname | tr '[:upper:]' '[:lower:]')-${arch}"
 }
 
 get_filename() {

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -10,7 +10,7 @@ get_platform() {
     aarch64) arch="arm64";;
     *) arch="amd64";;
   esac
-  echo "$(uname | tr '[:upper:]' '[:lower:]')-${arch}"
+  echo "$(uname | tr '[:upper:]' '[:lower:]')_${arch}"
 }
 
 get_filename() {


### PR DESCRIPTION
Flux releases binaries for various system architectures, but this asdf plugin is currently hardcoded to use only amd64. This change will use the `uname -m` command to detect the system's architecture and install the correct binary for each host system. The amd64 binary does not work on arm64 devices, and returns a seg fault whenever attempting to run it. 
```bash
user@raspberrypi:~$ asdf install flux2 latest
Downloading Flux v2 from https://github.com/fluxcd/flux2/releases/download/v0.27.4/flux_0.27.4_linux_amd64.tar.gz
############################################################################################################# 100.0%############################################################################################################# 100.0%
Copying Binary
binary_path/download:/opt/asdf/downloads/flux2/0.27.4/flux
Installing Binary
user@raspberrypi:~$ asdf global flux2 latest
user@raspberrypi:~$ flux --version
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault (core dumped)
```

Below are the tests that I did to ensure this change works for arm devices and it does not break existing functionality.

```bash
# Rasberry pi (linux arm64)
user@raspberrypi:~$ asdf plugin add flux2 https://github.com/mathew-fleisch/asdf-flux2.git
user@raspberrypi:~$ asdf install flux2 latest
Downloading Flux v2 from https://github.com/fluxcd/flux2/releases/download/v0.27.4/flux_0.27.4_linux_arm64.tar.gz
############################################################################################################# 100.0%############################################################################################################# 100.0%
Copying Binary
binary_path/download:/opt/asdf/downloads/flux2/0.27.4/flux
Installing Binary
user@raspberrypi:~$ asdf global flux2 latest
user@raspberrypi:~$ flux --version
flux version 0.27.4



# Macbook Pro (darwin amd64)
user@macbookpro asdf-flux2 % asdf plugin add flux2 https://github.com/mathew-fleisch/asdf-flux2.git
user@macbookpro asdf-flux2 % asdf install flux2 latest
Downloading Flux v2 from https://github.com/fluxcd/flux2/releases/download/v0.27.4/flux_0.27.4_darwin_amd64.tar.gz
############################################################################################################# 100.0%
Copying Binary
binary_path/download:/opt/asdf/downloads/flux2/0.27.4/flux
Installing Binary
user@macbookpro asdf-flux2 % asdf global flux2 latest 
user@macbookpro asdf-flux2 % flux --version
flux version 0.27.4
```